### PR TITLE
Update README.md to add alternate subscribe link

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,3 +61,6 @@ Here's the current list of supportable __GTCA__ properties. To get more added, r
 
 ### Commenting
 * `__themeCfg.disqusUsername`
+
+### Publishing
+* `__themeCfg.alternateSubscribeLink` - defines an alternative to the built-in RSS link (ex: [Feedburner](http://feedburner.google.com/) feed)


### PR DESCRIPTION
Added alternate subscribe link for situations where the user needs to use something other than the built in RSS link provided by Ghost. The subscription button is changed to the alternate subscribe link during page load. It does not change the server-side output for the alternate link for the site.
